### PR TITLE
Deeper inheritance tree from Controller/ApiController and check fully qualified name.

### DIFF
--- a/ControllerDiagnostics/ControllerDiagnostics.Test/ControllerNamingConventionTests.cs
+++ b/ControllerDiagnostics/ControllerDiagnostics.Test/ControllerNamingConventionTests.cs
@@ -14,11 +14,9 @@ namespace ControllerDiagnostics.Test
         public void MvcClassWithoutConstructorFixes()
         {
             var test = @"
-using System.Web.Mvc;
-
 namespace WebApplicationCS.Controllers
 {
-    public class HomeControllerTest : Controller
+    public class HomeControllerTest : System.Web.Mvc.Controller
     {
         public ActionResult Index()
         {
@@ -33,18 +31,16 @@ namespace WebApplicationCS.Controllers
                 Severity = DiagnosticSeverity.Warning,
                 Locations =
                     new[] {
-                            new DiagnosticResultLocation("Test0.cs", 6, 18)
+                            new DiagnosticResultLocation("Test0.cs", 4, 18)
                         }
             };
 
             VerifyCSharpDiagnostic(test, expected);
 
             var fixtest = @"
-using System.Web.Mvc;
-
 namespace WebApplicationCS.Controllers
 {
-    public class HomeTestController : Controller
+    public class HomeTestController : System.Web.Mvc.Controller
     {
         public ActionResult Index()
         {
@@ -61,11 +57,9 @@ namespace WebApplicationCS.Controllers
         public void MvcClassNotEndingInControllerCreatesDiagnostics()
         {
             var test = @"
-using System.Web.Mvc;
-
 namespace WebApplicationCS.Controllers
 {
-    public class HomeControllerTest : Controller
+    public class HomeControllerTest : System.Web.Mvc.Controller
     {
 		public HomeControllerTest()
 		{
@@ -84,18 +78,16 @@ namespace WebApplicationCS.Controllers
                 Severity = DiagnosticSeverity.Warning,
                 Locations =
                     new[] {
-                            new DiagnosticResultLocation("Test0.cs", 6, 18)
+                            new DiagnosticResultLocation("Test0.cs", 4, 18)
                         }
             };
 
             VerifyCSharpDiagnostic(test, expected);
 
             var fixtest = @"
-using System.Web.Mvc;
-
 namespace WebApplicationCS.Controllers
 {
-    public class HomeTestController : Controller
+    public class HomeTestController : System.Web.Mvc.Controller
     {
 		public HomeTestController()
 		{
@@ -115,11 +107,9 @@ namespace WebApplicationCS.Controllers
         public void MvcClassEndingInControllerDoesNotCreateDiagnostic()
         {
             var test = @"
-using System.Web.Mvc;
-
 namespace WebApplicationCS.Controllers
 {
-    public class HomeTestController : Controller
+    public class HomeTestController : System.Web.Mvc.Controller
     {
 		public HomeConTest()
 		{
@@ -140,11 +130,9 @@ namespace WebApplicationCS.Controllers
         public void WebApiClassNotEndingInControllerCreatesDiagnostics()
         {
             var test = @"
-using System.Web.Http;
-
 namespace WebApplicationCS.Controllers
 {
-    public class HomeConTest : ApiController
+    public class HomeConTest : System.Web.Http.ApiController
     {
 		public HomeConTest()
 		{
@@ -160,7 +148,7 @@ namespace WebApplicationCS.Controllers
                 Severity = DiagnosticSeverity.Warning,
                 Locations =
         new[] {
-                            new DiagnosticResultLocation("Test0.cs", 6, 18)
+                            new DiagnosticResultLocation("Test0.cs", 4, 18)
                         }
             };
 
@@ -168,11 +156,9 @@ namespace WebApplicationCS.Controllers
             VerifyCSharpDiagnostic(test, expected);
 
             var fixtest = @"
-using System.Web.Http;
-
 namespace WebApplicationCS.Controllers
 {
-    public class HomeConTestController : ApiController
+    public class HomeConTestController : System.Web.Http.ApiController
     {
 		public HomeConTestController()
 		{


### PR DESCRIPTION
First of all, thank you for your talk at QL's TechCon! I've made a first attempt (well, third if we're being honest) at tackling the bug you mentioned. While there are still issues with the approach, I haven't come up with a better one.

1) Tried to use `Compilation.GetTypeByMetadataName(string)` but it would require having references to the two dlls, which seems contrary to the reason for doing this in Rosyln in the first place.
2) Originally used a `while(true)` in the extension, but that felt dirty/dangerous.

With where I ended up, I also had to change all the test cases to provide the fully qualified name because it would convert the base types into "ErrorType {type name}" (e.g. "ErrorType Controller").

I'd love feedback on what does/doesn't work in the changes. Thanks!